### PR TITLE
Keep compatible with pycountry >= 18.5.27

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,14 @@ python:
   # https://github.com/travis-ci/travis-ci/issues/2219#issuecomment-41804942
   # https://snarky.ca/how-to-use-your-project-travis-to-help-test-python-itself/
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.5-dev"
   - "3.6"
   - "3.6-dev"
+  #- "3.7" https://github.com/travis-ci/travis-ci/issues/9069#issuecomment-425720905
   - "3.7-dev"
+  #- "3.8-dev" https://github.com/travis-ci/travis-ci/issues/9069#issuecomment-425720905
   - "nightly"
 before_install:
   # install dependencies for NumPy
@@ -20,7 +21,7 @@ before_install:
   - sudo apt-get install -qq pandoc
 install:
   - pip install -U pip wheel setuptools
-  - pip install -U --use-wheel pytest pytest-cov
+  - pip install -U pytest pytest-cov
   - python setup.py install
   - pip install -U tinysegmenter jieba
   - python -c "import nltk; nltk.download('punkt')"

--- a/sumy/utils.py
+++ b/sumy/utils.py
@@ -24,8 +24,9 @@ _HTTP_HEADERS = {
 def normalize_language(language):
     for lookup_key in ("alpha_2", "alpha_3"):
         try:
-            language = languages.get(**{lookup_key: language})
-            return language.name.lower()
+            lang = languages.get(**{lookup_key: language})
+            if lang:
+                language = lang.name.lower()
         except KeyError:
             pass
 


### PR DESCRIPTION
Language lookup can now return `None`.

Also tests in TravisCI needed to be adjusted to test this.
1) Remove deprecated pip option `--use-wheel`.
2) Remove Python 3.3 from TravisCI. Reached end of life 2017-09-29, see https://www.python.org/dev/peps/pep-0398/#x-end-of-life